### PR TITLE
Fixing Charset in Content-Disposition of DataExporter

### DIFF
--- a/jsf-exporter-core/src/main/java/com/lapis/jsfexporter/DataExporter.java
+++ b/jsf-exporter-core/src/main/java/com/lapis/jsfexporter/DataExporter.java
@@ -163,7 +163,7 @@ public class DataExporter implements ActionListener, StateHolder {
 		 * See RFC 6266 and http://greenbytes.de/tech/tc2231/
 		 */
 		String encodedFileName = URLEncoder.encode(fileName.getValue(elContext) + "." + exportType.getFileExtension(), "UTF-8");
-		externalContext.setResponseHeader("Content-Disposition", "attachment; filename=\"" + encodedFileName + "\"; filename*=UTF8''" + encodedFileName);
+		externalContext.setResponseHeader("Content-Disposition", "attachment; filename=\"" + encodedFileName + "\"; filename*=UTF-8''" + encodedFileName);
 		
 		// write the response and signal JSF that we're done
 		exportType.writeExport(externalContext);


### PR DESCRIPTION
Given CharSet has a typo in UTF8. Has to be UTF-8. Chrome and Firefox
can deal with it but IE 11 does not recognize the correct filename.
